### PR TITLE
added empty content array to advice-generator.config.ts

### DIFF
--- a/src/styles/advice-generator.config.ts
+++ b/src/styles/advice-generator.config.ts
@@ -5,6 +5,7 @@ import type { PluginAPI } from "tailwindcss/types/config";
 
 export default {
   name: "advice-generator",
+  content: [],
   selectors: [".advice-generator", "[data-theme='advice-generator']"],
   screens: {
     mobile: "375px",


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request introduces a minor change to the `advice-generator.config.ts` file in the `src/styles` directory. The `content` property has been added to the default export object.
> 
> ## What changed
> The `advice-generator.config.ts` file was modified. A new property `content` was added to the default export object. The `content` property is an empty array.
> 
> ```diff
>   export default {
>     name: "advice-generator",
> +   content: [],
>     selectors: [".advice-generator", "[data-theme='advice-generator']"],
>     screens: {
>       mobile: "375px",
> ```
> 
> ## How to test
> To test this change, follow these steps:
> 
> 1. Pull the changes from this branch into your local environment.
> 2. Navigate to the `src/styles` directory.
> 3. Open the `advice-generator.config.ts` file.
> 4. Verify that the `content` property exists in the default export object and is an empty array.
> 
> ## Why make this change
> The `content` property was added to allow for future expansion of the `advice-generator` theme. This property can be used to specify the content that should be styled by the theme. Currently, it is an empty array, but it can be populated with selectors as needed in the future.
</details>